### PR TITLE
Use libp2p to start a relay server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+libp2p = "0.43"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use tokio;
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt};
+mod relay;
 
 #[tokio::main]
 async fn main() {
@@ -7,6 +8,11 @@ async fn main() {
     let mut stdout = io::stdout();
     let mut reader = io::BufReader::new(stdin);
     let mut buffer = String::new();
+
+    // Start the relay server
+    if let Err(e) = relay::start_relay_server() {
+        eprintln!("Failed to start relay server: {}", e);
+    }
 
     loop {
         buffer.clear();

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,0 +1,44 @@
+use libp2p::{
+    core::transport::upgrade,
+    dns::DnsConfig,
+    identity,
+    noise::{Keypair, NoiseConfig, X25519Spec},
+    relay::{self, RelayConfig},
+    swarm::SwarmBuilder,
+    tcp::TcpConfig,
+    yamux::YamuxConfig,
+    Multiaddr, PeerId, Swarm, Transport,
+};
+use std::error::Error;
+use tokio::runtime::Runtime;
+
+pub fn start_relay_server() -> Result<(), Box<dyn Error>> {
+    let local_key = identity::Keypair::generate_ed25519();
+    let local_peer_id = PeerId::from(local_key.public());
+
+    let transport = DnsConfig::system(TcpConfig::new().nodelay(true))?
+        .upgrade(upgrade::Version::V1)
+        .authenticate(NoiseConfig::xx(Keypair::<X25519Spec>::new().into_authentic(&local_key)?))
+        .multiplex(YamuxConfig::default())
+        .boxed();
+
+    let relay_config = RelayConfig::default();
+    let behaviour = relay::Behaviour::new(local_peer_id, relay_config);
+
+    let mut swarm = SwarmBuilder::new(transport, behaviour, local_peer_id)
+        .executor(Box::new(|fut| {
+            tokio::spawn(fut);
+        }))
+        .build();
+
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        loop {
+            match swarm.next().await {
+                _ => {}
+            }
+        }
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
Add `libp2p` dependency and implement relay server functionality.

* **Cargo.toml**
  - Add `libp2p` version "0.43" to dependencies.

* **src/relay.rs**
  - Import necessary `libp2p` modules.
  - Define `start_relay_server` function to initialize and run a relay server using `libp2p`.
  - Configure transport, authentication, multiplexing, and relay behavior.

* **src/main.rs**
  - Import `start_relay_server` function from `relay.rs`.
  - Call `start_relay_server` function in the `main` function and handle potential errors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Lunkle/crowdwork/pull/5?shareId=7cf76124-f6dc-45a7-8c4c-1454fe241230).